### PR TITLE
Change the way dev loop works

### DIFF
--- a/Loungeware/scripts/___private_functions/___private_functions.gml
+++ b/Loungeware/scripts/___private_functions/___private_functions.gml
@@ -82,9 +82,9 @@ function ___microgame_start(_microgame_propname){
 			sprite_delete(garbo_sprites[| 0]);
 			ds_list_delete(garbo_sprites, 0);
 		}
-
+		var _test_vars = ___global.test_vars;
+		
 		var _metadata = variable_struct_get(___global.microgame_metadata, _microgame_propname);
-
 		microgame_current_metadata = _metadata;
 		microgame_current_name = _microgame_propname;
 		
@@ -173,7 +173,7 @@ function ___microgame_end(){
 	microgame_next_name = microgame_unplayed_list[| irandom_range(0, ds_list_size(microgame_unplayed_list) - 1)];
 	microgame_next_metadata = variable_struct_get(___global.microgame_metadata, microgame_next_name);
 	
-	if (dev_mode && variable_struct_exists(___global.microgame_metadata, ___global.test_vars.microgame_key)){
+	if (dev_mode && ___global.test_vars.loop_game){
 		microgame_next_name = microgame_current_name;
 		microgame_next_metadata = microgame_current_metadata;
 	}

--- a/Loungeware/scripts/___private_functions/___private_functions.gml
+++ b/Loungeware/scripts/___private_functions/___private_functions.gml
@@ -82,8 +82,9 @@ function ___microgame_start(_microgame_propname){
 			sprite_delete(garbo_sprites[| 0]);
 			ds_list_delete(garbo_sprites, 0);
 		}
-		
+
 		var _metadata = variable_struct_get(___global.microgame_metadata, _microgame_propname);
+
 		microgame_current_metadata = _metadata;
 		microgame_current_name = _microgame_propname;
 		
@@ -172,7 +173,7 @@ function ___microgame_end(){
 	microgame_next_name = microgame_unplayed_list[| irandom_range(0, ds_list_size(microgame_unplayed_list) - 1)];
 	microgame_next_metadata = variable_struct_get(___global.microgame_metadata, microgame_next_name);
 	
-	if (dev_mode && ___global.test_vars.loop_game){
+	if (dev_mode && variable_struct_exists(___global.microgame_metadata, ___global.test_vars.microgame_key)){
 		microgame_next_name = microgame_current_name;
 		microgame_next_metadata = microgame_current_metadata;
 	}

--- a/Loungeware/scripts/___private_functions/___private_functions.gml
+++ b/Loungeware/scripts/___private_functions/___private_functions.gml
@@ -82,6 +82,7 @@ function ___microgame_start(_microgame_propname){
 			sprite_delete(garbo_sprites[| 0]);
 			ds_list_delete(garbo_sprites, 0);
 		}
+		
 
 		var _metadata = variable_struct_get(___global.microgame_metadata, _microgame_propname);
 		microgame_current_metadata = _metadata;

--- a/Loungeware/scripts/___private_functions/___private_functions.gml
+++ b/Loungeware/scripts/___private_functions/___private_functions.gml
@@ -82,8 +82,7 @@ function ___microgame_start(_microgame_propname){
 			sprite_delete(garbo_sprites[| 0]);
 			ds_list_delete(garbo_sprites, 0);
 		}
-		var _test_vars = ___global.test_vars;
-		
+
 		var _metadata = variable_struct_get(___global.microgame_metadata, _microgame_propname);
 		microgame_current_metadata = _metadata;
 		microgame_current_name = _microgame_propname;

--- a/Loungeware/scripts/___private_functions/___private_functions.gml
+++ b/Loungeware/scripts/___private_functions/___private_functions.gml
@@ -83,7 +83,6 @@ function ___microgame_start(_microgame_propname){
 			ds_list_delete(garbo_sprites, 0);
 		}
 		
-
 		var _metadata = variable_struct_get(___global.microgame_metadata, _microgame_propname);
 		microgame_current_metadata = _metadata;
 		microgame_current_name = _microgame_propname;

--- a/Loungeware/scripts/__microgame_metadata/__microgame_metadata.gml
+++ b/Loungeware/scripts/__microgame_metadata/__microgame_metadata.gml
@@ -7,7 +7,8 @@ function ___init_metadata(){
 		microgame_key: "",
 		loop_game: false,
 		difficulty_level: 1,
-		mute_test: false
+		mute_test: false,
+		skip_transition_animation: false
 	}
 	
 	var env = __try_read_json("config.dev.json");
@@ -18,7 +19,8 @@ function ___init_metadata(){
 			microgame_key: variable_struct_exists(env, "microgame_key") ? env[$"microgame_key"]: "",
 			loop_game: variable_struct_exists(env, "loop_game") ? env[$"loop_game"]: false,
 			difficulty_level: variable_struct_exists(env, "difficulty_level") ? env[$"difficulty_level"]: false,
-			mute_test: variable_struct_exists(env, "mute_test") ? env[$"mute_test"]: false
+			mute_test: variable_struct_exists(env, "mute_test") ? env[$"mute_test"]: false,
+			skip_transition_animation: variable_struct_exists(env, "skip_transition_animation") ? env[$"skip_transition_animation"]: false,
 		}
 	}
 	


### PR DESCRIPTION
As a dev I find the dev loop mode a bit confusing.
 
 Typically I want to do 1 of 3 things 
1) Test my game back to back with no cartridge 
2) Test my game back to back, but WITH the cartridge animation to test sounds and cart colors / label 
3) Play all games 

We currently support 
1) Test my game back to back, the current loop mode. 
2) Test my game first, but then go into everyone else games showing carts
3) Play all games 

#2 in currently supported is what I take issue with. I don't really ever want to test my game first, and then other peoples games. I want to test my game back to back, but with the cartridge. If i wanted to play other games I just wouldn't set my key or turn dev mode off.

Solution: 
If test mode on and dev key is set, always load my micro game 

if loop mode is on, don't show cart previews


Now, this will play game back to back, no cart
```
dev_mode: true,
microgame_key: 'n8fl_blast',
loop: true
```

Now this will play back to back, with cart
```
dev_mode: true,
microgame_key: 'n8fl_blast',
loop: false
```


