### PR TITLE
Added new date format to microgame metadata

### DIFF
--- a/Loungeware/scripts/___LW_FGameLoader/___LW_FGameLoader.gml
+++ b/Loungeware/scripts/___LW_FGameLoader/___LW_FGameLoader.gml
@@ -158,6 +158,20 @@ function LW_FGameLoaderStringTransformer(field_name, default_value) : LW_FGameLo
 }
 
 function LW_FGameLoaderDateTransformer(field_name, default_value) : LW_FGameLoaderTransformer(field_name, default_value) constructor {
+    monthNames = {
+        january : 1, jan : 1,
+        february : 2, feb : 2,
+        march : 3, mar : 3,
+        april : 4, apr : 4,
+        may : 5,
+        june : 6, jun : 6,
+        july : 7, jul : 7,
+        august : 8, aug : 8,
+        september : 9, sep : 9, sept : 9,
+        october : 10, oct : 10, spooky : 10,
+        november : 11, nov : 11,
+        december : 12, dec : 12, jolly : 12,
+    };
     _is_valid_internal = function(val) {
         if (is_string(val)) {
             return string_length(val) > 0;
@@ -171,7 +185,7 @@ function LW_FGameLoaderDateTransformer(field_name, default_value) : LW_FGameLoad
             var mm = val.month;
             var yy = val.year;
             return is_numeric(dd) && dd >= 1 && dd <= 99 &&
-                    is_numeric(mm) && mm >= 1 && mm <= 12 &&
+                    (is_numeric(mm) && mm >= 1 && mm <= 12 || is_string(mm) && variable_struct_exists(monthNames, string_lower(mm))) &&
                     is_numeric(yy) && (yy >= 2000 && yy <= 2099 || yy >= 0 && yy <= 99);
         } else {
             return false;
@@ -180,7 +194,7 @@ function LW_FGameLoaderDateTransformer(field_name, default_value) : LW_FGameLoad
     _get_value_internal = function(val) {
         if (is_struct(val)) {
             var day = string_format(val.day, 2, 0);
-            var month = string_format(val.month, 2, 0);
+            var month = string_format(is_string(val.month) ? monthNames[$ string_lower(val.month)] : val.month, 2, 0);
             var year = string_format(val.year >= 2000 ? val.year - 2000 : val.year, 2, 0);
             return string_replace_all(year + "/" + month + "/" + day, " ", "0");
         } else {

--- a/Loungeware/scripts/___LW_FGameLoader/___LW_FGameLoader.gml
+++ b/Loungeware/scripts/___LW_FGameLoader/___LW_FGameLoader.gml
@@ -157,6 +157,37 @@ function LW_FGameLoaderStringTransformer(field_name, default_value) : LW_FGameLo
 	_get_value_internal = function(val) { return string(val); }
 }
 
+function LW_FGameLoaderDateTransformer(field_name, default_value) : LW_FGameLoaderTransformer(field_name, default_value) constructor {
+    _is_valid_internal = function(val) {
+        if (is_string(val)) {
+            return string_length(val) > 0;
+        } else if (is_struct(val)) {
+            if not (variable_struct_exists(val, "day") &&
+                    variable_struct_exists(val, "month") &&
+                    variable_struct_exists(val, "year")) {
+                return false;
+            }
+            var dd = val.day;
+            var mm = val.month;
+            var yy = val.year;
+            return is_numeric(dd) && dd >= 1 && dd <= 99 &&
+                    is_numeric(mm) && mm >= 1 && mm <= 12 &&
+                    is_numeric(yy) && (yy >= 2000 && yy <= 2099 || yy >= 0 && yy <= 99);
+        } else {
+            return false;
+        }
+    }
+    _get_value_internal = function(val) {
+        if (is_struct(val)) {
+            var day = string_format(val.day, 2, 0);
+            var month = string_format(val.month, 2, 0);
+            var year = string_format(val.year >= 2000 ? val.year - 2000 : val.year, 2, 0);
+            return string_replace_all(year + "/" + month + "/" + day, " ", "0");
+        } else {
+            return string(val);
+        }
+    }
+}
 
 function LW_FGameLoaderSoundTransformer(field_name, default_value) : LW_FGameLoaderTransformer(field_name, default_value) constructor 
 {

--- a/Loungeware/scripts/___microgame_metadata/___microgame_metadata.gml
+++ b/Loungeware/scripts/___microgame_metadata/___microgame_metadata.gml
@@ -46,7 +46,7 @@ function microgame_register(microgame_name, metadata){
 				.set_min(1)
 				.set_inner_validator(function(val) { return is_string(val); })
 			)
-		.add_rule(new LW_FGameLoaderStringTransformer("date_added", undefined))
+		.add_rule(new LW_FGameLoaderDateTransformer("date_added", undefined))
 		.get_rules();
 		
 		global.___MetaGameLoader.set_rules(rules);

--- a/Loungeware/scripts/katsaii_metadata/katsaii_metadata.gml
+++ b/Loungeware/scripts/katsaii_metadata/katsaii_metadata.gml
@@ -16,5 +16,9 @@ microgame_register("katsaii_witchwanda", {
     default_is_fail : true,
     supports_difficulty_scaling : true,
     credits : ["Katsaii", "Mashmerlow"],
-    date_added : "21/07/09"
+    date_added : {
+        day : 9,
+        month : 7,
+        year : 21
+    }
 });

--- a/Loungeware/scripts/katsaii_metadata/katsaii_metadata.gml
+++ b/Loungeware/scripts/katsaii_metadata/katsaii_metadata.gml
@@ -18,7 +18,7 @@ microgame_register("katsaii_witchwanda", {
     credits : ["Katsaii", "Mashmerlow"],
     date_added : {
         day : 9,
-        month : 7,
-        year : 21
-    }
+        month : "July",
+        year : 2021
+    },
 });


### PR DESCRIPTION
Strings can still be used, but are heavily suggested against. The new format is:
```js
{
  day : ... , // a number between 1 and 99
  month : ... , // a number between 1 and 12 OR a graphical month name, such as "december" or "feb"
  year : ... , // a number between 1 and 99 OR between 2000 and 2099
}
```
For example, the metadata for Witch Wanda now looks like:
```js
{
  day : 9,
  month : "July",
  year : 2021
}
```
The order of the fields does not matter, and the case of month names is ignored.