### PR TITLE
beenade windows fix 2024

### DIFF
--- a/Loungeware/objects/NahooRunner/Create_0.gml
+++ b/Loungeware/objects/NahooRunner/Create_0.gml
@@ -253,7 +253,6 @@ function nahoo_run(m)
 		//You fucking died!
 		microgame_fail();
 		return nahoo_end(0);
-		nahoo_log("You died!")
 	}
 	
 	// Move around
@@ -479,8 +478,16 @@ function nahoo_cum_process(m)
 	}
 	
 	var empty = ((array_length(m) + 1) * (array_length(m[0]) + 1)) - walls;
-	flood = m;
-	
+
+	flood = [[]];
+	for(var i = 0; i < array_length(m); i++)
+	{
+		for(var j = 0; j < array_length(m[0]); j++)
+		{
+			flood[i][j] = m[i][j];
+		}
+	}
+
 	for(var i = 0; i < array_length(m); i++)
 	{
 		for(var j = 0; j < array_length(m[0]); j++)
@@ -544,7 +551,11 @@ function nahoo_cum_process(m)
 
 function nahoo_Array2D(w, h, def)
 {
-	var arr = array_create(w, array_create(h, def));
+	var arr = array_create(w);
+	var len = array_length(arr);
+	for (var i = 0; i < len; i++) {
+		arr[i] = array_create(h, def);
+	}
 	return arr;
 }
 


### PR DESCRIPTION
Beenade was broken on windows
(game was always either an instant loss, or would freeze the game with a do loop)

This PR fixes the issues which caused this.

---
first issue was in the `nahoo_Array2D` function (line 547):
```var arr = array_create(w, array_create(h, def));```

the second array_create only runs once, returning an array reference. then the second array_create sets all of its values to that array reference.
So  now you have an array filled with references to the same array, meaning if you make any changes to one of them, it changes every single row in an identical way.

I changed this so all the rows use unique arrays (presumably as it was intended to).

strangely, this worked fine on HTML.

---

second issue was in the `nahoo_c*m_process` function  (line 482)
```flood = m;```
seems that the function tried to make a copy of the map so that it could edit it for a flood fill  test without editing the original map arrays. but it stopped making copies at some point and now instead, changes the original.

I'm assuming this used work (probably what used to happen is that the array got copied when it got passed into the function. yoyo made changes to copy-on-write that probably broke this ?)

i fixed this by making a true copy of the map, using a loop.

---

I believe everything should now work exactly as it did before yoyo broke this


